### PR TITLE
fix: add missing ExifHistory fields and remove duplicate migration columns

### DIFF
--- a/Sources/VernissageServer/Migrations/CreateExif.swift
+++ b/Sources/VernissageServer/Migrations/CreateExif.swift
@@ -15,8 +15,6 @@ extension Exif {
             try await database
                 .schema(Exif.schema)
                 .field(.id, .int64, .identifier(auto: false))
-                .field("parameters", .varchar(10240))
-                .field("workflow", .varchar(65536))
                 .field("make", .varchar(50))
                 .field("model", .varchar(50))
                 .field("lens", .varchar(50))

--- a/Sources/VernissageServer/Models/ExifHistory.swift
+++ b/Sources/VernissageServer/Models/ExifHistory.swift
@@ -96,7 +96,10 @@ final class ExifHistory: Model, @unchecked Sendable {
         self.fNumber = exif.fNumber
         self.exposureTime = exif.exposureTime
         self.photographicSensitivity = exif.photographicSensitivity
+        self.software = exif.software
         self.film = exif.film
+        self.chemistry = exif.chemistry
+        self.scanner = exif.scanner
         self.latitude = exif.latitude
         self.longitude = exif.longitude
         self.flash = exif.flash


### PR DESCRIPTION
## Summary

Two bugs in the EXIF handling code on the `fartgram-clean` branch.

### Bug 1: ExifHistory missing software, chemistry, scanner

`ExifHistory.init(id:attachmentHistoryId:from:)` copies all Exif fields into a history snapshot when a post is edited, but skips `software`, `chemistry`, and `scanner`. Every other field is copied -- these three are simply missing from the init body despite being declared as `@Field` properties on the model.

This means every edit-history record silently loses those three values.

**Fix:** Add the three missing assignments after `photographicSensitivity` and before `latitude`, matching the field declaration order.

### Bug 2: CreateExif.prepare duplicates parameters/workflow columns

`CreateExif.prepare` declares `.field("parameters")` and `.field("workflow")` in the initial table creation. But `AddParameters` and `AddWorkflow` migration structs also add those same columns via `.update()`. On a fresh database install (or SQLite test run), the table is created with both columns already present, then the later migrations try to add them again and fail with a duplicate column error.

Every other extended field (`film`, `software`, `gps`, `flash`, `focalLength`) only uses the separate migration struct pattern and is NOT included in `CreateExif.prepare`.

**Fix:** Remove the two lines from `CreateExif.prepare` so the columns are only added by their dedicated migration structs.

Relates to mchaker/VernissageServer#2